### PR TITLE
Feature/base repository improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@roq/core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roq/core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Roq core package",
   "main": "dist/src/index.js",
   "files": [

--- a/src/library/interfaces/index.ts
+++ b/src/library/interfaces/index.ts
@@ -12,6 +12,7 @@ export type { ValueInFilterInterface } from './value-in-filter.interface';
 export type { ValueNotInFilterInterface } from './value-not-in-filter.interface';
 export type { DateFilterInterface } from './date-filter.interface';
 export type { QueryFilterInterface } from './query-filter.interface';
+export type { QueryOrderInterface } from './query-order.interface';
 export type { MoreThanEqualFilterInterface } from './more-than-equal-filter.interface';
 export type { LessThanEqualFilterInterface } from './less-than-equal-filter.interface';
 export type { GraphqlContextInterface } from 'src/library/interfaces/graphql-context.interface';

--- a/src/library/interfaces/query-order.interface.ts
+++ b/src/library/interfaces/query-order.interface.ts
@@ -1,0 +1,6 @@
+import { OrderEnum } from "src/library/enums";
+
+export interface QueryOrderInterface {
+    order: OrderEnum;
+    sort: string;
+}

--- a/src/library/interfaces/query.interface.ts
+++ b/src/library/interfaces/query.interface.ts
@@ -1,5 +1,4 @@
-import { OrderEnum } from 'src/library/enums';
-import { QueryFilterInterface } from 'src/library/interfaces';
+import { QueryFilterInterface, QueryOrderInterface } from 'src/library/interfaces';
 
 export interface QueryInterface {
   offset?: number;
@@ -11,9 +10,6 @@ export interface QueryInterface {
   };
   id?: string;
   ids?: string[];
-  order?: {
-    order: OrderEnum;
-    sort: string;
-  };
+  order?: QueryOrderInterface
   filter?: QueryFilterInterface;
 }

--- a/src/library/repositories/base.repository.ts
+++ b/src/library/repositories/base.repository.ts
@@ -82,7 +82,7 @@ export class BaseRepository<T> extends Repository<T> {
     return q;
   }
 
-  private processFilter(
+  protected processFilter(
     filter: QueryFilterInterface,
     entityMetadata: EntityMetadata,
     tableName: string,


### PR DESCRIPTION
Allows to override processFilter by making it protected
Allows to order results by joined tables by adding join and orderby field from joined table in similar way how filter is working.
As an example by having User and Company tables by specifying 
```{
  "order": {
    "order": "ASC",
    "sort": "company.revenue"
  }
}
```

it will be possible to get the array of users sorted by company revenue assuming user has company relation